### PR TITLE
feature/23-clear-queue - Clear OperationQueue on disconnection

### DIFF
--- a/Sources/SwiftyTeeth/Device.swift
+++ b/Sources/SwiftyTeeth/Device.swift
@@ -125,6 +125,7 @@ extension Device {
         let item = QueueItem<[Service]>(
             name: "discoverServices", // TODO: Need better than a hardcoded string
             execution: { (cb) in
+
                 guard self.isConnected == true else {
                     Log(v: "Not connected - cannot discoverServices", tag: self.tag)
                     cb(.failure(ConnectionError.disconnected))
@@ -293,6 +294,7 @@ internal extension Device {
     func didDisconnect() {
         Log(v: "didDisconnect: Calling disconnection handler: Is handler nil? \(connectionHandler == nil)", tag: tag)
         queue.cancelAll()
+
         connectionHandler?(.disconnected)
         connectionStateChangedHandler?(.disconnected)
         if autoReconnect == true {

--- a/Sources/SwiftyTeeth/Device.swift
+++ b/Sources/SwiftyTeeth/Device.swift
@@ -292,6 +292,7 @@ internal extension Device {
     
     func didDisconnect() {
         Log(v: "didDisconnect: Calling disconnection handler: Is handler nil? \(connectionHandler == nil)", tag: tag)
+        queue.cancelAll()
         connectionHandler?(.disconnected)
         connectionStateChangedHandler?(.disconnected)
         if autoReconnect == true {

--- a/Sources/SwiftyTeeth/Extensions/OperationQueue+SwiftyQueue.swift
+++ b/Sources/SwiftyTeeth/Extensions/OperationQueue+SwiftyQueue.swift
@@ -18,7 +18,7 @@ extension OperationQueue: SwiftyQueue {
         self.addOperation(item)
         Log(v: "SwiftyQueue: Now there are \(items.count) items in queue")
         for item in items {
-            Log(v: "SwiftyQueue: About to be cancelled \(item.name ?? "(none)")")
+            Log(v: "SwiftyQueue: \(item.name ?? "(none)") is in the queue")
         }
     }
     
@@ -27,7 +27,6 @@ extension OperationQueue: SwiftyQueue {
         for item in items {
             Log(v: "SwiftyQueue: About to be cancelled \(item.name ?? "(none)")")
         }
-        Log(v: "SwiftyQueue: Adding item to existing \(items.count) items in queue")
         self.cancelAllOperations()
     }
 }

--- a/Sources/SwiftyTeeth/Extensions/OperationQueue+SwiftyQueue.swift
+++ b/Sources/SwiftyTeeth/Extensions/OperationQueue+SwiftyQueue.swift
@@ -16,12 +16,18 @@ extension OperationQueue: SwiftyQueue {
     func pushBack(_ item: Operation) {
         Log(v: "SwiftyQueue: Adding item to existing \(items.count) items in queue")
         self.addOperation(item)
+        Log(v: "SwiftyQueue: Now there are \(items.count) items in queue")
+        for item in items {
+            Log(v: "SwiftyQueue: About to be cancelled \(item.name ?? "(none)")")
+        }
     }
     
     func cancelAll() {
         Log(v: "SwiftyQueue: Cancelling all \(items.count) items in queue")
+        for item in items {
+            Log(v: "SwiftyQueue: About to be cancelled \(item.name ?? "(none)")")
+        }
+        Log(v: "SwiftyQueue: Adding item to existing \(items.count) items in queue")
         self.cancelAllOperations()
     }
-    
-    
 }

--- a/Sources/SwiftyTeeth/Extensions/OperationQueue+SwiftyQueue.swift
+++ b/Sources/SwiftyTeeth/Extensions/OperationQueue+SwiftyQueue.swift
@@ -14,10 +14,12 @@ extension OperationQueue: SwiftyQueue {
     }
     
     func pushBack(_ item: Operation) {
+        Log(v: "SwiftyQueue: Adding item to existing \(items.count) items in queue")
         self.addOperation(item)
     }
     
     func cancelAll() {
+        Log(v: "SwiftyQueue: Cancelling all \(items.count) items in queue")
         self.cancelAllOperations()
     }
     

--- a/Sources/SwiftyTeeth/QueueItem.swift
+++ b/Sources/SwiftyTeeth/QueueItem.swift
@@ -91,6 +91,7 @@ public class QueueItem<T>: Operation {
 extension QueueItem: Queueable {
     
     func execute() {
+        Log(v: "QueueItem: Executing \(self.name ?? "(none)")")
         if let execution = execution {
             execution { (result) in
                 // Allow an early exit from the task if execution was a failure
@@ -107,6 +108,7 @@ extension QueueItem: Queueable {
     }
     
     func notify(_ result: Result<T, Error>) {
+        Log(v: "QueueItem: Notifying \(self.name ?? "(none)")")
         if let cb = callback {
             cb(result) {
                 done()

--- a/Sources/SwiftyTeeth/QueueItem.swift
+++ b/Sources/SwiftyTeeth/QueueItem.swift
@@ -80,6 +80,11 @@ public class QueueItem<T>: Operation {
         state = .executing
         execute()
     }
+
+    public override func cancel() {
+        super.cancel()
+        done()
+    }
     
     // Call this after Execute is completed to allow Queue to continue
     public func done() {


### PR DESCRIPTION
Closes issue #23 
Related to issue #27 

There are some edge cases that I've recently run into where the execute function fires, the peripheral disconnects, and then we never get the callback. Then, we can't re-discover services, because there is an unclearable item in the front of the queue

Currently, isCancelled is checked only BEFORE the operation starts executing, not during.