### PR TITLE
Swift 5.9 fixes

### DIFF
--- a/Sources/SwiftyTeeth/QueueItem.swift
+++ b/Sources/SwiftyTeeth/QueueItem.swift
@@ -22,7 +22,7 @@ public class QueueItem<T>: Operation {
     public typealias ExecutionBlock = ((Result<T, Error>) -> Void) -> Void
     
     @available(*, deprecated, message: "Don't use this")
-    override open var completionBlock: (() -> Void)? {
+    override open var completionBlock: (@Sendable() -> Void)? {
         get {
             return nil
         }


### PR DESCRIPTION
- Whitespace tweaks for consistency
- Fixes for Swift 5.9 warnings
- Fix for Swift 5.9 compilation error in Sources/SwiftyTeeth/QueueItem.swift